### PR TITLE
Split up directional kurtosis calculation into sub-functions.

### DIFF
--- a/dipy/reconst/dki.py
+++ b/dipy/reconst/dki.py
@@ -367,7 +367,44 @@ def _F2m(a, b, c):
     return F2
 
 
-def _directional_kurtosis(dt, MD, kt, V, min_diffusivity=0, min_kurtosis=-3/7):
+def _adc(dt, V, min_diffusivity=0):
+    ADC = \
+        V[:, 0] * V[:, 0] * dt[0] + \
+        2 * V[:, 0] * V[:, 1] * dt[1] + \
+        V[:, 1] * V[:, 1] * dt[2] + \
+        2 * V[:, 0] * V[:, 2] * dt[3] + \
+        2 * V[:, 1] * V[:, 2] * dt[4] + \
+        V[:, 2] * V[:, 2] * dt[5]
+
+    if min_diffusivity is not None:
+        ADC = ADC.clip(min=min_diffusivity)
+    return ADC
+
+
+def _akc(kt, V, min_kurtosis=-3/7):
+    AKC = \
+        V[:, 0] * V[:, 0] * V[:, 0] * V[:, 0] * kt[0] + \
+        V[:, 1] * V[:, 1] * V[:, 1] * V[:, 1] * kt[1] + \
+        V[:, 2] * V[:, 2] * V[:, 2] * V[:, 2] * kt[2] + \
+        4 * V[:, 0] * V[:, 0] * V[:, 0] * V[:, 1] * kt[3] + \
+        4 * V[:, 0] * V[:, 0] * V[:, 0] * V[:, 2] * kt[4] + \
+        4 * V[:, 0] * V[:, 1] * V[:, 1] * V[:, 1] * kt[5] + \
+        4 * V[:, 1] * V[:, 1] * V[:, 1] * V[:, 2] * kt[6] + \
+        4 * V[:, 0] * V[:, 2] * V[:, 2] * V[:, 2] * kt[7] + \
+        4 * V[:, 1] * V[:, 2] * V[:, 2] * V[:, 2] * kt[8] + \
+        6 * V[:, 0] * V[:, 0] * V[:, 1] * V[:, 1] * kt[9] + \
+        6 * V[:, 0] * V[:, 0] * V[:, 2] * V[:, 2] * kt[10] + \
+        6 * V[:, 1] * V[:, 1] * V[:, 2] * V[:, 2] * kt[11] + \
+        12 * V[:, 0] * V[:, 0] * V[:, 1] * V[:, 2] * kt[12] + \
+        12 * V[:, 0] * V[:, 1] * V[:, 1] * V[:, 2] * kt[13] + \
+        12 * V[:, 0] * V[:, 1] * V[:, 2] * V[:, 2] * kt[14]
+
+    if min_kurtosis is not None:
+        AKC = AKC.clip(min=min_kurtosis)
+    return AKC
+
+def _directional_kurtosis(dt, md, kt, V, min_diffusivity=0, min_kurtosis=-3/7,
+                          adc=None, akc=None):
     r""" Helper function that calculate the apparent kurtosis coefficient (AKC)
     in each direction of a sphere for a single voxel [1]_.
 
@@ -375,7 +412,7 @@ def _directional_kurtosis(dt, MD, kt, V, min_diffusivity=0, min_kurtosis=-3/7):
     ----------
     dt : array (6,)
         elements of the diffusion tensor of the voxel.
-    MD : float
+    md : float
         mean diffusivity of the voxel
     kt : array (15,)
         elements of the kurtosis tensor of the voxel.
@@ -412,38 +449,11 @@ def _directional_kurtosis(dt, MD, kt, V, min_diffusivity=0, min_kurtosis=-3/7):
            Biomedical Imaging: From Nano to Macro, ISBI 2011, 262-265.
            doi: 10.1109/ISBI.2011.5872402
     """
-    ADC = \
-        V[:, 0] * V[:, 0] * dt[0] + \
-        2 * V[:, 0] * V[:, 1] * dt[1] + \
-        V[:, 1] * V[:, 1] * dt[2] + \
-        2 * V[:, 0] * V[:, 2] * dt[3] + \
-        2 * V[:, 1] * V[:, 2] * dt[4] + \
-        V[:, 2] * V[:, 2] * dt[5]
-
-    if min_diffusivity is not None:
-        ADC = ADC.clip(min=min_diffusivity)
-
-    AKC = \
-        V[:, 0] * V[:, 0] * V[:, 0] * V[:, 0] * kt[0] + \
-        V[:, 1] * V[:, 1] * V[:, 1] * V[:, 1] * kt[1] + \
-        V[:, 2] * V[:, 2] * V[:, 2] * V[:, 2] * kt[2] + \
-        4 * V[:, 0] * V[:, 0] * V[:, 0] * V[:, 1] * kt[3] + \
-        4 * V[:, 0] * V[:, 0] * V[:, 0] * V[:, 2] * kt[4] + \
-        4 * V[:, 0] * V[:, 1] * V[:, 1] * V[:, 1] * kt[5] + \
-        4 * V[:, 1] * V[:, 1] * V[:, 1] * V[:, 2] * kt[6] + \
-        4 * V[:, 0] * V[:, 2] * V[:, 2] * V[:, 2] * kt[7] + \
-        4 * V[:, 1] * V[:, 2] * V[:, 2] * V[:, 2] * kt[8] + \
-        6 * V[:, 0] * V[:, 0] * V[:, 1] * V[:, 1] * kt[9] + \
-        6 * V[:, 0] * V[:, 0] * V[:, 2] * V[:, 2] * kt[10] + \
-        6 * V[:, 1] * V[:, 1] * V[:, 2] * V[:, 2] * kt[11] + \
-        12 * V[:, 0] * V[:, 0] * V[:, 1] * V[:, 2] * kt[12] + \
-        12 * V[:, 0] * V[:, 1] * V[:, 1] * V[:, 2] * kt[13] + \
-        12 * V[:, 0] * V[:, 1] * V[:, 2] * V[:, 2] * kt[14]
-
-    if min_kurtosis is not None:
-        AKC = AKC.clip(min=min_kurtosis)
-
-    return (MD / ADC) ** 2 * AKC
+    if adc is None:
+        adc = _adc(dt, V, min_diffusivity=min_diffusivity)
+    if akc is None:
+        akc = _akc(kt, V, min_kurtosis=min_kurtosis)
+    return (md / adc) ** 2 * akc
 
 
 def apparent_kurtosis_coef(dki_params, sphere, min_diffusivity=0,

--- a/dipy/reconst/tests/test_dki.py
+++ b/dipy/reconst/tests/test_dki.py
@@ -444,10 +444,10 @@ def test_single_voxel_DKI_stats():
     RDi = 0
     RDe = 0.00087
     # Reference values
-    AD = fie*ADi + (1-fie)*ADe
-    AK = 3 * fie * (1-fie) * ((ADi-ADe) / AD) ** 2
-    RD = fie*RDi + (1-fie)*RDe
-    RK = 3 * fie * (1-fie) * ((RDi-RDe) / RD) ** 2
+    AD = fie * ADi + (1 - fie) * ADe
+    AK = 3 * fie * (1 - fie) * ((ADi-ADe) / AD) ** 2
+    RD = fie * RDi + (1 - fie) * RDe
+    RK = 3 * fie * (1 - fie) * ((RDi-RDe) / RD) ** 2
     ref_vals = np.array([AD, AK, RD, RK])
 
     # simulate fiber randomly oriented
@@ -455,7 +455,7 @@ def test_single_voxel_DKI_stats():
     phi = random.uniform(0, 320)
     angles = [(theta, phi), (theta, phi)]
     mevals = np.array([[ADi, RDi, RDi], [ADe, RDe, RDe]])
-    frac = [fie*100, (1-fie)*100]
+    frac = [fie * 100, (1 - fie) * 100]
     signal, dt, kt = multi_tensor_dki(gtab_2s, mevals, S0=100, angles=angles,
                                       fractions=frac, snr=None)
     evals, evecs = decompose_tensor(from_lower_triangular(dt))
@@ -676,7 +676,7 @@ def test_multi_voxel_kurtosis_maximum():
     RDE = ADE / Tor
 
     # prepare simulation:
-    DWIsim = np.zeros((2., 2., 2., gtab_2s.bvals.size))
+    DWIsim = np.zeros((2, 2, 2, gtab_2s.bvals.size))
 
     for i in range(2):
         for j in range(2):

--- a/dipy/reconst/tests/test_dki_micro.py
+++ b/dipy/reconst/tests/test_dki_micro.py
@@ -143,7 +143,7 @@ def test_wmti_model_multi_voxel():
     RDE = ADE / Tor
 
     # prepare simulation:
-    DWIsim = np.zeros((2., 2., 2., gtab_2s.bvals.size))
+    DWIsim = np.zeros((2, 2, 2, gtab_2s.bvals.size))
 
     for i in range(2):
         for j in range(2):


### PR DESCRIPTION
This is so that we can calculate these in batch, and reuse.